### PR TITLE
use modern permission format

### DIFF
--- a/donorsearch.php
+++ b/donorsearch.php
@@ -82,7 +82,10 @@ function changeDSNavigation($action) {
  * Implements hook_civicrm_permission().
  */
 function donorsearch_civicrm_permission(&$permissions) {
-  $permissions += array('access DonorSearch' => ts('Access DonorSearch', array('domain' => 'com.greenleafadvancement.donorsearch')));
+  $permissions['access DonorSearch'] = [
+    'label' => E::ts('Access DonorSearch'),
+    'description' => E::ts('Grants permission to access DonorSearch'),
+  ];
 }
 
 /**


### PR DESCRIPTION
The current format for defining permissions is deprecated, this uses the new format, which doesn't throw warnings on CiviCRM 5.71+.